### PR TITLE
Tox and travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.pyo
 dist
 slacker.egg-info
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+sudo: false
+env:
+    - TOXENV=py26
+    - TOXENV=py27
+    - TOXENV=py33
+    - TOXENV=py34
+    - TOXENV=pypy
+
+install:
+    - travis_retry pip install tox
+
+script:
+    - travis_retry tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, py34, pypy
+
+[testenv]
+deps = -r{toxinidir}/requirements-dev.txt
+       pytest
+commands = py.test tests/


### PR DESCRIPTION
```
$ pip install tox
...
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
```

Passing Travis CI build: https://travis-ci.org/msabramo/slacker/builds/43786595

To turn on Travis CI for your repo, see http://docs.travis-ci.com/user/getting-started/