### PR TITLE
use response.raise_for_status() instead of assert

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -50,7 +50,7 @@ class BaseAPI(object):
         response = method(API_BASE_URL.format(api=api),
                           **kwargs)
 
-        assert response.status_code == 200
+        response.raise_for_status()
 
         response = Response(response.text)
         if not response.successful:


### PR DESCRIPTION
requests has a built in method for handling http errors
http://docs.python-requests.org/en/latest/api/#requests.Response.raise_for_status