### PR TITLE
Update example: make bot send messages as user

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Examples
     slack = Slacker('<your-slack-api-token-goes-here>')
 
     # Send a message to #general channel
-    slack.chat.post_message('#general', 'Hello fellow slackers!')
+    slack.chat.post_message('#general', 'Hello fellow slackers!', as_user=True)
 
     # Get users list
     response = slack.users.list()


### PR DESCRIPTION
When sending a message without the `as_user` option, it does not use Bot's preferences as configured
![screen shot 2015-10-31 at 10 16 06 am](https://cloud.githubusercontent.com/assets/1192342/10862621/8c40a7f8-7fb8-11e5-90cb-171f0d7571d6.png)

When adding `as_user=True` though, it displays everything correctly.
![screen shot 2015-10-31 at 10 16 37 am](https://cloud.githubusercontent.com/assets/1192342/10862622/8e53a752-7fb8-11e5-8abe-368a60cdd0f2.png)

