### PR TITLE
fixes chat delete and update not returning response

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -258,11 +258,11 @@ class Chat(BaseAPI):
                          })
 
     def update(self, channel, ts, text):
-        self.post('chat.update',
+        return self.post('chat.update',
                   data={'channel': channel, 'ts': ts, 'text': text})
 
     def delete(self, channel, ts):
-        self.post('chat.delete', data={'channel': channel, 'ts': ts})
+        return self.post('chat.delete', data={'channel': channel, 'ts': ts})
 
 
 class IM(BaseAPI):


### PR DESCRIPTION
these two functions (`delete` and `update`) don't return the response from the slack api calls. I discovered this while attempting to check the response 'ok' key returned by slack.