### PR TITLE
Added chat.command with basic functionality

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -258,6 +258,15 @@ class Chat(BaseAPI):
                              'icon_emoji': icon_emoji
                          })
 
+
+    def command(self, channel, command, text):
+        return self.post('chat.command',
+                         data={
+                             'channel': channel,
+                             'command': command,
+                             'text': text
+                         })
+
     def update(self, channel, ts, text, attachments=None, parse=None,
                link_names=False, as_user=None):
         # Ensure attachments are json encoded


### PR DESCRIPTION
This change enables executing slash commands through the API. While it isn't documented, chat.command can be seen in use in the Slack web UI. `command` is the slash command to apply, for example `giphy` or `todo` or `catfact`. `text` is the query or arguments to the slash command. 