### PR TITLE
Adding tagify methods for channels and users.

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -134,7 +134,7 @@ class Users(BaseAPI):
 
     def tagify(self, text):
         members = self.list().body['members']
-        mem_map = [('#{}'.format(c['name']), '<#{}>'.format(c['id'])) for c in members]
+        mem_map = [('@{}'.format(c['name']), '<@{}>'.format(c['id'])) for c in members]
 
         for k,v in mem_map:
             text = text.replace(k,v)

--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -135,6 +135,7 @@ class Users(BaseAPI):
     def tagify(self, text):
         members = self.list().body['members']
         mem_map = [('@{}'.format(c['name']), '<@{}>'.format(c['id'])) for c in members]
+        mem_map.extend([('@here', '<!here>'), ('@channel', '<!channel>'), ('@everyone', '<!everyone>')])
 
         for k,v in mem_map:
             text = text.replace(k,v)

--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -132,6 +132,15 @@ class Users(BaseAPI):
         members = self.list().body['members']
         return get_item_id_by_name(members, user_name)
 
+    def tagify(self, text):
+        members = self.list().body['members']
+        mem_map = [('#{}'.format(c['name']), '<#{}>'.format(c['id'])) for c in members]
+
+        for k,v in mem_map:
+            text = text.replace(k,v)
+
+        return text
+
 
 class Groups(BaseAPI):
     def create(self, name):
@@ -260,6 +269,14 @@ class Channels(BaseAPI):
         channels = self.list().body['channels']
         return get_item_id_by_name(channels, channel_name)
 
+    def tagify(self, text):
+        channels = self.list().body['channels']
+        ch_map = [('#{}'.format(c['name']), '<#{}>'.format(c['id'])) for c in channels]
+
+        for k,v in ch_map:
+            text = text.replace(k,v)
+
+        return text
 
 class Chat(BaseAPI):
     def post_message(self, channel, text, username=None, as_user=None,


### PR DESCRIPTION
A simple pair of methods that will go through a string and replace all the raw user and channel tags with the matching [unique character strings](https://api.slack.com/docs/message-formatting#linking_to_channels_and_users) that link them in bodies of text.