### PR TITLE
make sure empty lists are also json encoded

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -302,7 +302,7 @@ class Chat(BaseAPI):
     def update(self, channel, ts, text, attachments=None, parse=None,
                link_names=False, as_user=None):
         # Ensure attachments are json encoded
-        if attachments and isinstance(attachments, list):
+        if attachments is not None and isinstance(attachments, list):
             attachments = json.dumps(attachments)
         return self.post('chat.update',
                          data={


### PR DESCRIPTION
When updating a message on slack there's a difference between not providing an attachments argument and providing an empty list. In the former case the attachments are left as is while providing an empty list updates the message to have no attachments.

With this patch the attachments will be json encoded also in the case when providing an empty list.