### PR TITLE
Add threading arguments to Chat method

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -265,7 +265,7 @@ class Chat(BaseAPI):
     def post_message(self, channel, text, username=None, as_user=None,
                      parse=None, link_names=None, attachments=None,
                      unfurl_links=None, unfurl_media=None, icon_url=None,
-                     icon_emoji=None):
+                     icon_emoji=None, thread_ts=None, reply_broadcast=None):
 
         # Ensure attachments are json encoded
         if attachments:
@@ -284,7 +284,9 @@ class Chat(BaseAPI):
                              'unfurl_links': unfurl_links,
                              'unfurl_media': unfurl_media,
                              'icon_url': icon_url,
-                             'icon_emoji': icon_emoji
+                             'icon_emoji': icon_emoji,
+                             'thread_ts': thread_ts,
+                             'reply_broadcast': reply_broadcast
                          })
 
     def me_message(self, channel, text):


### PR DESCRIPTION
Enabling the new [chat.postMessage arguments](https://api.slack.com/methods/chat.postMessage) as explained in Slack's [blog post](https://slackhq.com/threaded-messaging-comes-to-slack-417ffba054bd).

- `thread_ts`
- `reply_broadcast`