### PR TITLE
Specify required python versions a more travish way to make them work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 language: python
 
+python:
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "pypy"
+
 sudo: false
-env:
-    - TOXENV=py26
-    - TOXENV=py27
-    - TOXENV=py33
-    - TOXENV=py34
-    - TOXENV=pypy
 
 install:
     - travis_retry pip install tox
 
 script:
+    # set the TOXENV to the python environment selected by the travis agent
+    - export TOXENV="$(if [ "${TRAVIS_PYTHON_VERSION}" == "pypy" ]; then echo "pypy"; else echo py${TRAVIS_PYTHON_VERSION/\./}; fi)"
     - travis_retry tox


### PR DESCRIPTION
PR #118 and #120 failed on travis, simply because the python version under test was not available in the container.

This changes the behavior to have travis explicitly install the required version and pass that version by getting the TOXENV from an automatically set environment variable.