### PR TITLE
Add the new method of chat.getPermalink

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -435,6 +435,13 @@ class Chat(BaseAPI):
                              'user_auth_url': user_auth_url,
                          })
 
+    def get_permalink(self, channel, message_ts):
+        return self.get('chat.getPermalink',
+                        params={
+                            'channel': channel,
+                            'message_ts': message_ts
+                        })
+
 
 class IM(BaseAPI):
     def list(self):


### PR DESCRIPTION
I added the new method of [chat.getPermalink](https://api.slack.com/methods/chat.getPermalink) to Chat class.

Usage example
```
slack = Slacker('<your-slack-api-token-goes-here>')
response = slack.chat.get_permalink('<channel>', '<message_ts>')
```

Response example
```
{
    "ok": true,
    "channel": "C1H9RESGA",
    "permalink": "https:\/\/ghostbusters.slack.com\/archives\/C1H9RESGA\/p135854651500008"
}
```
