### PR TITLE
Allow a file handle to be passed for files.upload

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -601,8 +601,14 @@ class Files(BaseAPI):
 
         if file_:
             if isinstance(file_, str):
-                file_ = open(file_, 'rb')
-            return self.post('files.upload', data=data, files={'file': file_})
+                with open(file_, 'rb') as f:
+                    return self.post(
+                        'files.upload', data=data, files={'file': f}
+                    )
+
+            return self.post(
+                'files.upload', data=data, files={'file': file_}
+            )
         else:
             return self.post('files.upload', data=data)
 

--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -600,7 +600,7 @@ class Files(BaseAPI):
         }
 
         if file_:
-            if type(file_) in types.StringTypes:
+            if isinstance(file_, str):
                 file_ = open(file_, 'rb')
             return self.post('files.upload', data=data, files={'file': file_})
         else:

--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -600,8 +600,9 @@ class Files(BaseAPI):
         }
 
         if file_:
-            with open(file_, 'rb') as f:
-                return self.post('files.upload', data=data, files={'file': f})
+            if type(file_) in types.StringTypes:
+                file_ = open(file_, 'rb')
+            return self.post('files.upload', data=data, files={'file': file_})
         else:
             return self.post('files.upload', data=data)
 


### PR DESCRIPTION
Currently the file must exist on disk, however sometimes it's useful to use a file handle directly.