### PR TITLE
Changed error result with response_metadata field

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -47,6 +47,12 @@ class Response(object):
         self.body = json.loads(body)
         self.successful = self.body['ok']
         self.error = self.body.get('error')
+        self.response_metadata = self.body.get('response_metadata')
+        if self.response_metadata:
+            self.error = '{} - {}'.format(
+                self.error,
+                ','.join(self.response_metadata.get('messages')),
+            )
 
     def __str__(self):
         return json.dumps(self.body)


### PR DESCRIPTION
Changed error result with response_metadata field set to something with more context

Turns response.error variable from: 
`Error: validation_errors`
to
`Error: validation_errors - [ERROR] Element 2 field 'label' cannot be longer than 24 characters`
if the response JSON body has a field `response_metadata` that is not empty.