### PR TITLE
Add blocks support to Slacker

### DIFF
--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -357,7 +357,7 @@ class Chat(BaseAPI):
     def post_message(self, channel, text=None, username=None, as_user=None,
                      parse=None, link_names=None, attachments=None,
                      unfurl_links=None, unfurl_media=None, icon_url=None,
-                     icon_emoji=None, thread_ts=None, reply_broadcast=None):
+                     icon_emoji=None, thread_ts=None, reply_broadcast=None, blocks=None):
 
         # Ensure attachments are json encoded
         if attachments:
@@ -378,7 +378,8 @@ class Chat(BaseAPI):
                              'icon_url': icon_url,
                              'icon_emoji': icon_emoji,
                              'thread_ts': thread_ts,
-                             'reply_broadcast': reply_broadcast
+                             'reply_broadcast': reply_broadcast,
+                             'blocks': blocks
                          })
 
     def me_message(self, channel, text):
@@ -394,7 +395,7 @@ class Chat(BaseAPI):
                          })
 
     def update(self, channel, ts, text, attachments=None, parse=None,
-               link_names=False, as_user=None):
+               link_names=False, as_user=None, blocks=None):
         # Ensure attachments are json encoded
         if attachments is not None and isinstance(attachments, list):
             attachments = json.dumps(attachments)
@@ -407,6 +408,7 @@ class Chat(BaseAPI):
                              'parse': parse,
                              'link_names': int(link_names),
                              'as_user': as_user,
+                             'blocks': blocks
                          })
 
     def delete(self, channel, ts, as_user=False):
@@ -418,7 +420,7 @@ class Chat(BaseAPI):
                          })
 
     def post_ephemeral(self, channel, text, user, as_user=None,
-                       attachments=None, link_names=None, parse=None):
+                       attachments=None, link_names=None, parse=None, blocks=None):
         # Ensure attachments are json encoded
         if attachments is not None and isinstance(attachments, list):
             attachments = json.dumps(attachments)
@@ -431,6 +433,7 @@ class Chat(BaseAPI):
                              'attachments': attachments,
                              'link_names': link_names,
                              'parse': parse,
+                             'blocks': blocks
                          })
 
     def unfurl(self, channel, ts, unfurls, user_auth_message=None,


### PR DESCRIPTION
This commit will add the ability to use blocks to Chat.post_message, Chat.update, and Chat.post_ephemeral.

Blocks are an optional ability to add visual effects using json-like structure. Slack has been pushing its use since early 2019.

This is an attempt to squash and re-PR this. I am the newbest, so if this doesn't work, I'm just gonna let someone else make the like, 25 character change to have this work.