### PR TITLE
Make users.list accept pagination args

### DIFF
--- a/examples/list.py
+++ b/examples/list.py
@@ -5,7 +5,19 @@
 # https://api.slack.com/methods
 
 import os
+import functools
 from slacker import Slacker
+
+
+def paginated(list_func):
+    # See https://api.slack.com/docs/pagination
+    next_cursor = None
+    while True:
+        response = list_func(cursor=next_cursor)
+        yield response
+        next_cursor = response.body['response_metadata']['next_cursor']
+        if not next_cursor:
+            break
 
 
 def list_slack():
@@ -14,22 +26,14 @@ def list_slack():
         token = os.environ['SLACK_TOKEN']
         slack = Slacker(token)
 
-        # Get channel list
-        response = slack.channels.list()
-        channels = response.body['channels']
-        for channel in channels:
-            print(channel['id'], channel['name'])
-            # if not channel['is_archived']:
-            # slack.channels.join(channel['name'])
-        print()
-
-        # Get users list
-        response = slack.users.list()
-        users = response.body['members']
-        for user in users:
-            if not user['deleted']:
-                print(user['id'], user['name'], user['is_admin'], user[
-                    'is_owner'])
+        # Get users list, with pagination
+        for response in paginated(functools.partial(slack.users.list, limit=150)):
+            print("=== page === ")
+            users = response.body['members']
+            for user in users:
+                if not user['deleted']:
+                    print(user['id'], user['name'], user['is_admin'], user[
+                        'is_owner'])
         print()
     except KeyError as ex:
         print('Environment variable %s not set.' % str(ex))

--- a/slacker/__init__.py
+++ b/slacker/__init__.py
@@ -327,8 +327,15 @@ class Users(BaseAPI):
         return self.get('users.info',
                         params={'user': user, 'include_locale': include_locale})
 
-    def list(self, presence=False):
-        return self.get('users.list', params={'presence': int(presence)})
+    def list(self, presence=False, cursor=None, limit=None):
+        return self.get(
+            'users.list',
+            params={
+                'presence': int(presence),
+                'cursor': cursor,
+                'limit': limit,
+            }
+        )
 
     def identity(self):
         return self.get('users.identity')


### PR DESCRIPTION
This PR adds `cursor` and `limit` to `users.list` API to allow pagination per https://api.slack.com/docs/pagination.
API should be backward compatible.
I also modified example to show how paging is done.
I removed the channels part in example because that API is deprecated.